### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "puppeteer": "^11.0.0"
+        "puppeteer": "^19.4.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.0.0",


### PR DESCRIPTION
Puppeteer < 19.4.0 is no longer supported.